### PR TITLE
Add basic automation modules and integrate with UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # life_pattern_simulator
+
+간단한 생활 패턴 시뮬레이터 예제입니다. 다음과 같은 모듈을 포함합니다.
+
+* `test.py` – Tkinter 기반 시뮬레이션 UI. `rules.json`에 저장된 규칙을 읽어
+  시뮬레이션 시간에 맞춰 자동화 이벤트를 발생시킵니다.
+* `chatbot.py` – 터미널에서 동작하는 간단한 챗봇. 사용자의 입력을 바탕으로
+  자동화 규칙을 제안하고 `rules.json`에 저장합니다.
+* `rule_set.py` – 규칙을 관리하고 로드/저장하는 모듈.
+* `data_generator.py` – 스크립트 기반 데이터셋을 생성하여 CSV 파일로 저장
+  할 수 있는 도구.
+
+예시:
+
+```bash
+python chatbot.py  # 규칙 생성
+python test.py     # 시뮬레이션 UI 실행
+```

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,33 @@
+import re
+from rule_set import RuleSet
+
+class Chatbot:
+    """Very simple command-line chatbot for rule suggestions."""
+
+    def __init__(self, rules: RuleSet):
+        self.rules = rules
+
+    def suggest_rule(self, text: str) -> None:
+        text_lower = text.lower()
+        if "조명" in text_lower and "off" in text_lower:
+            print("매일 22:00에 조명을 끌까요? (Yes/No)")
+            ans = input().strip().lower()
+            if ans == "yes":
+                rule = {"device": "거실", "action": "OFF", "time": "22:00"}
+                self.rules.add_rule(rule)
+                print("규칙이 저장되었습니다.")
+        else:
+            print("현재는 추천할 규칙이 없습니다.")
+
+    def run(self) -> None:
+        print("자동화 권고 챗봇 (종료하려면 'quit' 입력)")
+        while True:
+            user_input = input("사용자 입력> ").strip()
+            if user_input.lower() in {"quit", "exit"}:
+                break
+            self.suggest_rule(user_input)
+
+if __name__ == "__main__":
+    rs = RuleSet()
+    bot = Chatbot(rs)
+    bot.run()

--- a/data_generator.py
+++ b/data_generator.py
@@ -1,0 +1,42 @@
+import csv
+from datetime import datetime, timedelta
+from typing import List, Dict
+
+
+def generate_script_data(script: List[Dict], start_date: str, days: int) -> List[Dict]:
+    """Generate time-series data based on a simple script.
+
+    Args:
+        script: list of dicts with keys 'time', 'device', 'action'.
+        start_date: starting date string 'YYYY-MM-DD'.
+        days: number of days to repeat the script.
+    """
+    result = []
+    start_dt = datetime.strptime(start_date, "%Y-%m-%d")
+    for d in range(days):
+        day_dt = start_dt + timedelta(days=d)
+        for entry in script:
+            hh_mm = datetime.strptime(entry["time"], "%H:%M").time()
+            dt = datetime.combine(day_dt, hh_mm)
+            result.append({"timestamp": dt.isoformat(),
+                           "device": entry["device"],
+                           "action": entry["action"]})
+    return result
+
+
+def save_csv(data: List[Dict], path: str) -> None:
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=["timestamp", "device", "action"])
+        writer.writeheader()
+        for row in data:
+            writer.writerow(row)
+
+
+if __name__ == "__main__":
+    SCRIPT = [
+        {"time": "22:00", "device": "거실", "action": "OFF"},
+        {"time": "07:00", "device": "거실", "action": "ON"},
+    ]
+    dataset = generate_script_data(SCRIPT, "2024-01-01", 2)
+    save_csv(dataset, "sample_data.csv")
+    print("sample_data.csv created")

--- a/rule_set.py
+++ b/rule_set.py
@@ -1,0 +1,29 @@
+import json
+from typing import List, Dict
+
+class RuleSet:
+    """Simple rule-set manager for automation rules."""
+
+    def __init__(self, path: str = "rules.json"):
+        self.path = path
+        self.rules: List[Dict] = []
+        self.load()
+
+    def load(self) -> None:
+        try:
+            with open(self.path, 'r', encoding='utf-8') as f:
+                self.rules = json.load(f)
+        except FileNotFoundError:
+            self.rules = []
+
+    def save(self) -> None:
+        with open(self.path, 'w', encoding='utf-8') as f:
+            json.dump(self.rules, f, ensure_ascii=False, indent=2)
+
+    def add_rule(self, rule: Dict) -> None:
+        """Add a new rule and persist it."""
+        self.rules.append(rule)
+        self.save()
+
+    def get_rules(self) -> List[Dict]:
+        return list(self.rules)

--- a/test.py
+++ b/test.py
@@ -1,8 +1,12 @@
+# 기본 UI 및 시뮬레이션 모듈
 import tkinter as tk
 from tkinter import ttk
 import threading
 import time
 import random
+
+# 규칙 기반 자동화를 위해 RuleSet 불러오기
+from rule_set import RuleSet
 # PIL 사용 시 주석 해제 (필요에 따라 사용)
 # from PIL import Image, ImageTk
 
@@ -15,6 +19,10 @@ class LearningDataCreationUI:
         self.simulation_running = False
         self.sim_time = 0  # 시뮬레이션 시간(분 단위)
         self.sim_speed = 1  # 시뮬레이션 배속 (1x, 2x, 3x, 5x, 10x)
+
+        # 저장된 자동화 규칙 로드
+        self.rule_set = RuleSet()
+        self.rules = self.rule_set.get_rules()
 
         # 각 디바이스(방)의 기본 색상 및 활성화 색상 설정
         self.off_colors = {"거실": "lightblue", "주방": "lightgreen", "침실": "lightyellow", "욕실": "lightpink"}
@@ -173,6 +181,17 @@ class LearningDataCreationUI:
             minutes = int(self.sim_time) % 60
             sim_time_str = f"{hours:02d}:{minutes:02d}"
             self.root.after(0, lambda t=sim_time_str: self.sim_time_label.config(text=f"시뮬레이션 시간: {t}"))
+
+            # 저장된 자동화 규칙 확인 후 적용
+            for rule in self.rules:
+                if rule.get("time") == sim_time_str:
+                    device = rule.get("device")
+                    activity = rule.get("action")
+                    if device and activity:
+                        self.root.after(0, lambda d=device, t=sim_time_str, a=activity: self.tree.insert("", tk.END, values=(d, t, "-", a)))
+                        if device in self.room_rects:
+                            new_color = self.on_colors[device] if activity.upper() == "ON" else self.off_colors[device]
+                            self.root.after(0, lambda d=device, color=new_color: self.floorplan_canvas.itemconfig(self.room_rects[d], fill=color))
             
             # 임의 이벤트 생성: 50% 확률로 이벤트 발생
             if random.random() < 0.5:


### PR DESCRIPTION
## Summary
- add rule_set manager and command-line chatbot for rule recommendations
- allow UI simulation to use saved rules
- provide script-based dataset generator
- expand README with usage instructions

## Testing
- `python -m py_compile test.py chatbot.py rule_set.py data_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68594a8e2c00832c914510a2aa3f600e