### PR TITLE
Fix device icon initialization

### DIFF
--- a/test.py
+++ b/test.py
@@ -5,6 +5,7 @@ import threading
 import time
 import random
 import csv
+import os
 from data_generator import generate_script_data, save_csv
 
 # 규칙 기반 자동화를 위해 RuleSet 불러오기
@@ -34,8 +35,9 @@ class LearningDataCreationUI:
         self.off_colors = {"거실": "lightblue", "주방": "lightgreen", "침실": "lightyellow", "욕실": "lightpink"}
         self.on_colors = {"거실": "blue", "주방": "green", "침실": "gold", "욕실": "red"}
 
-        # 평면도 상의 방 사각형 id를 저장할 딕셔너리
+        # 평면도 상의 방 사각형 id와 디바이스 아이콘을 저장할 딕셔너리
         self.room_rects = {}
+        self.device_icons: dict[str, int] = {}
 
         # 전체 화면을 상단 Frame(제목영역) / 메인영역(좌측=평면도, 우측=시계+테이블)으로 구분
         self.top_frame = tk.Frame(self.root, height=50, bg="lightgray")
@@ -376,4 +378,7 @@ class MainApp:
 if __name__ == "__main__":
     root = tk.Tk()
     app = LearningDataCreationUI(root)
+    if os.environ.get("HEADLESS"):
+        # Close the GUI automatically when running in headless mode
+        root.after(1000, root.destroy)
     root.mainloop()


### PR DESCRIPTION
## Summary
- fix missing `device_icons` dict initialization in `LearningDataCreationUI`
- support automated headless runs by closing GUI after a short delay when `HEADLESS` is set

## Testing
- `python -m py_compile *.py`
- `HEADLESS=1 xvfb-run -a python test.py`


------
https://chatgpt.com/codex/tasks/task_e_685a3c26a204832c95bef749c18e3cd8