### PR TITLE
Switch to Optional for type hints

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from typing import Tuple, List, Dict
+from typing import Tuple, List, Dict, Optional
 from rule_set import RuleSet
 from pattern_analyzer import load_csv, suggest_rules
 
@@ -22,13 +22,13 @@ class Chatbot:
                 print('규칙이 저장되었습니다.')
 
     @staticmethod
-    def _extract_time(text: str) -> str | None:
+    def _extract_time(text: str) -> Optional[str]:
         """Return first HH:MM string in the text if present."""
         match = re.search(r"([01]\d|2[0-3]):([0-5]\d)", text)
         return match.group(0) if match else None
 
     @staticmethod
-    def _extract_device_action(text: str) -> Tuple[str | None, str | None]:
+    def _extract_device_action(text: str) -> Tuple[Optional[str], Optional[str]]:
         text_lower = text.lower()
         device = None
         action = None
@@ -55,7 +55,7 @@ class Chatbot:
         else:
             print("예시: '22:00에 거실 조명 꺼줘'와 같이 입력해주세요.")
 
-    def run(self, dataset_path: str | None = None) -> None:
+    def run(self, dataset_path: Optional[str] = None) -> None:
         print("자동화 권고 챗봇 (종료하려면 'quit' 입력)")
 
         if dataset_path:

--- a/test.py
+++ b/test.py
@@ -6,6 +6,7 @@ import time
 import random
 import csv
 import os
+from typing import Optional
 from data_generator import generate_script_data, save_csv
 
 # 규칙 기반 자동화를 위해 RuleSet 불러오기
@@ -288,7 +289,7 @@ class LearningDataCreationUI:
         except ValueError:
             self.sim_speed = 1
 
-    def start_simulation(self, duration_minutes: int | None = None):
+    def start_simulation(self, duration_minutes: Optional[int] = None):
         if not self.simulation_running:
             self.simulation_running = True
             self.sim_time = 0


### PR DESCRIPTION
## Summary
- import Optional in `test.py` and update `start_simulation` signature
- update `chatbot.py` to use `Optional` type hints instead of the `| None` syntax

## Testing
- `python -m py_compile chatbot.py test.py data_generator.py pattern_analyzer.py rule_set.py train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_685a4dd7acb8832ca852a6ab3c0d5a5d