### PR TITLE
Implement simple Chatbot UI

### DIFF
--- a/chatbot_gui.py
+++ b/chatbot_gui.py
@@ -1,0 +1,49 @@
+import tkinter as tk
+from rule_set import RuleSet
+
+class ChatbotUI:
+    """Simple Tkinter chatbot interface for rule confirmations."""
+
+    def __init__(self, master: tk.Tk, rule_set: RuleSet, on_rule_added=None):
+        self.master = master
+        self.master.title("Home Control Chatbot")
+        self.rule_set = rule_set
+        self.on_rule_added = on_rule_added
+
+        self.text_area = tk.Text(self.master, state="disabled", width=40, height=15)
+        self.text_area.pack(padx=10, pady=10)
+
+        self.entry = tk.Entry(self.master)
+        self.entry.pack(fill=tk.X, padx=10, pady=(0, 10))
+        self.entry.bind("<Return>", self.on_enter)
+
+        self.pending_rule = None
+
+    def display(self, text: str, sender: str = "bot") -> None:
+        prefix = "Bot: " if sender == "bot" else "You: "
+        self.text_area.config(state="normal")
+        self.text_area.insert(tk.END, prefix + text + "\n")
+        self.text_area.see(tk.END)
+        self.text_area.config(state="disabled")
+
+    def ask_yes_no(self, message: str, rule: dict) -> None:
+        self.pending_rule = rule
+        self.display(message)
+
+    def on_enter(self, event=None) -> None:
+        user_text = self.entry.get().strip()
+        if not user_text:
+            return
+        self.entry.delete(0, tk.END)
+        self.display(user_text, sender="user")
+
+        if self.pending_rule:
+            if user_text.lower() == "yes":
+                self.rule_set.add_rule(self.pending_rule)
+                self.display("규칙이 저장되었습니다.")
+                if self.on_rule_added:
+                    self.on_rule_added()
+            else:
+                self.display("규칙이 저장되지 않았습니다.")
+            self.pending_rule = None
+

--- a/test.py
+++ b/test.py
@@ -7,6 +7,7 @@ import random
 import csv
 from data_generator import generate_script_data, save_csv
 from pattern_analyzer import load_csv, suggest_rules
+from chatbot_gui import ChatbotUI
 
 # 규칙 기반 자동화를 위해 RuleSet 불러오기
 from rule_set import RuleSet
@@ -342,6 +343,10 @@ class MainApp:
 
         self.data_tab = LearningDataCreationUI(self.tab1)
 
+        # 별도 창에 Chatbot UI 생성
+        self.chatbot_window = tk.Toplevel(root)
+        self.chatbot = ChatbotUI(self.chatbot_window, self.data_tab.rule_set, on_rule_added=self.show_rules)
+
         # 학습 탭: 간단한 패턴 분석 실행 버튼
         tk.Button(self.tab2, text="패턴 분석", command=self.run_analysis).pack(pady=10)
         self.analysis_output = tk.Text(self.tab2, height=10)
@@ -370,9 +375,12 @@ class MainApp:
         for s in suggestions:
             line = f"{s['time']} {s['device']} {s['action']}\n"
             self.analysis_output.insert(tk.END, line)
+            message = f"매일 {s['time']}에 {s['device']}를 {s['action']} 하시겠습니까? (Yes/No)"
+            self.chatbot.ask_yes_no(message, s)
 
     def show_rules(self):
         self.rule_text.delete("1.0", tk.END)
+        self.data_tab.rules = self.data_tab.rule_set.get_rules()
         for r in self.data_tab.rules:
             self.rule_text.insert(tk.END, f"{r}\n")
 


### PR DESCRIPTION
## Summary
- create `ChatbotUI` Tkinter interface
- integrate Chatbot window into the main simulator
- show suggested rules through the Chatbot UI

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a724000d4832cad8c06654710f9c8